### PR TITLE
fix: pin Neo4j version to 5.x.x for compatibility

### DIFF
--- a/data/neo4j/overlays/production/neo4j-stateful.yaml
+++ b/data/neo4j/overlays/production/neo4j-stateful.yaml
@@ -54,7 +54,7 @@ spec:
             path: /data/local/neo4j-backup
       containers:
         - name: neo4j
-          image: neo4j:enterprise
+          image: neo4j:5-enterprise
           ports:
             - containerPort: 7474
               hostPort: 7474


### PR DESCRIPTION
- Addresses discovery service version mismatch
- Ensures stability with current APOC version
- Prevents unintended upgrades to 2025.01+

More info: https://neo4j.com/docs/upgrade-migration-guide/current/version-2025/upgrade/#_cluster_discovery_service

## NOTE This is already actual on `cxs-eu1` via clickops by yours truly.