### PR TITLE
chore: update cxs-services image tag to fd23aba

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "fae0a5f"
+    newTag: "fd23aba"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Update cxs-services production image tag from `fae0a5f` to `fd23aba`

## Test plan
- [ ] ArgoCD auto-syncs the updated image tag to production
- [ ] Verify cxs-services pods are running with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)