### PR TITLE
Update image tag for synmetrix-client-v2

### DIFF
--- a/data/synmetrix/overlays/production/kustomization.yaml
+++ b/data/synmetrix/overlays/production/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
   - name: quicklookup/synmetrix-client-v2
-    newTag: "07787d2"
+    newTag: "d2e5e76"
   - name: quicklookup/synmetrix-actions
     newTag: "7270f8d"
   - name: quicklookup/synmetrix-cube


### PR DESCRIPTION
image update from 07787d2 to d2e5e76 in production overlay