### PR TITLE
chore: update cxs-services image tag to 2d66dbb

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "fd23aba"
+    newTag: "2d66dbb"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Update cxs-services production image tag from `fd23aba` to `2d66dbb`

## Test plan
- [ ] Verify ArgoCD picks up the new image tag and syncs successfully
- [ ] Confirm cxs-services pods are running with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)