### PR TITLE
chore: update contextsuite image tag to 92567c8

### DIFF
--- a/apps/contextsuite/overlays/production/kustomization.yaml
+++ b/apps/contextsuite/overlays/production/kustomization.yaml
@@ -1,6 +1,6 @@
 images:
   - name: quicklookup/contextsuite
-    newTag: e02956f
+    newTag: "92567c8"
 
 # Production configs reside in the base
 resources:

--- a/apps/contextsuite/overlays/staging/kustomization.yaml
+++ b/apps/contextsuite/overlays/staging/kustomization.yaml
@@ -1,6 +1,6 @@
 images:
   - name: quicklookup/contextsuite
-    newTag: 5504daf
+    newTag: "92567c8"
 
 configMapGenerator:
   - name: contextsuite-config


### PR DESCRIPTION
## Summary
- Update contextsuite image tag to `92567c8` in both staging and production overlays

## Test plan
- [ ] Verify ArgoCD picks up the new image tag for staging
- [ ] Verify ArgoCD picks up the new image tag for production

🤖 Generated with [Claude Code](https://claude.com/claude-code)