### PR TITLE
Route backup alerts to Serious Ops Notifications channel

### DIFF
--- a/monitoring/grafana/base/postgresql-backup-rules.yaml
+++ b/monitoring/grafana/base/postgresql-backup-rules.yaml
@@ -80,7 +80,7 @@ groups:
             severity: critical
           isPaused: false
           notification_settings:
-            receiver: Snjallgogn Teams
+            receiver: Snjallgogn Ops
 
         - uid: pg-backup-repo2-stale
           title: 'PostgreSQL: No successful backup to MinIO (repo2) in 28h'
@@ -157,4 +157,4 @@ groups:
             severity: critical
           isPaused: false
           notification_settings:
-            receiver: Snjallgogn Teams
+            receiver: Snjallgogn Ops


### PR DESCRIPTION
## Summary

- Update `notification_settings.receiver` from `Snjallgogn Teams` (Pod Notifications) to `Snjallgogn Ops` (Serious Ops Notifications) for both PostgreSQL backup staleness alerts
- Database backup failures are critical and belong in the ops channel, not alongside routine pod notifications

## Changes (1 file)

| File | Change | Risk |
|------|--------|------|
| `monitoring/grafana/base/postgresql-backup-rules.yaml` | Change receiver on both rules | LOW — receiver name change only |

Longhorn alerts remain on "Snjallgogn Teams" (Pod Notifications) — unaffected.

## Test plan

- [ ] After ArgoCD sync, verify alerts show "Snjallgogn Ops" receiver in Grafana UI
- [ ] Confirm Grafana pod restarts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)