### PR TITLE
chore: update cxs-services image tag to 7a72c0d

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "2d66dbb"
+    newTag: "7a72c0d"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Update `cxs-services` production image tag from `2d66dbb` to `7a72c0d`

## Test plan
- [ ] Verify ArgoCD syncs the updated image tag
- [ ] Confirm cxs-services pods are running with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)