### PR TITLE
chore: update production image tags for cxs-mimir-api and cxs-services

### DIFF
--- a/apps/cxs-mimir-api/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-mimir-api
-    newTag: "2f25256"
+    newTag: "7a72c0d"
 
 resources:
   - ../../base

--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "7a72c0d"
+    newTag: "2d66dbb"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Update `cxs-mimir-api` production image tag from `2f25256` to `7a72c0d`
- Revert `cxs-services` production image tag from `7a72c0d` back to `2d66dbb`

## Test plan
- [ ] Verify ArgoCD syncs both updated image tags
- [ ] Confirm cxs-mimir-api pods are running with the new image
- [ ] Confirm cxs-services pods are running with the reverted image

🤖 Generated with [Claude Code](https://claude.com/claude-code)