### PR TITLE
chore: update cxs-services image tag to 44ac372 in production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "2d66dbb"
+    newTag: "44ac372"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Updates `cxs-services` production image tag from `2d66dbb` to `44ac372`

## Test plan
- [ ] Verify ArgoCD syncs the updated image tag successfully
- [ ] Confirm cxs-services pods are running with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)