### PR TITLE
chore: revert cxs-services image tag to 2d66dbb in production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "44ac372"
+    newTag: "2d66dbb"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Reverts `cxs-services` production image tag from `44ac372` back to `2d66dbb`

## Test plan
- [ ] Verify ArgoCD syncs the reverted image tag successfully
- [ ] Confirm cxs-services pods are running with the previous image

🤖 Generated with [Claude Code](https://claude.com/claude-code)