### PR TITLE
chore: update cxs-mimir-api and cxs-services image tags to 7b5f338

### DIFF
--- a/apps/cxs-mimir-api/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-mimir-api
-    newTag: "7a72c0d"
+    newTag: "7b5f338"
 
 resources:
   - ../../base

--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "2d66dbb"
+    newTag: "7b5f338"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Update `cxs-mimir-api` production image tag from `7a72c0d` to `7b5f338`
- Update `cxs-services` production image tag to `7b5f338`

## Test plan
- [ ] Verify ArgoCD syncs both applications successfully
- [ ] Confirm cxs-mimir-api and cxs-services pods are running with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)