### PR TITLE
chore: update cxs-services image tag to 1c7e65f

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "7b5f338"
+    newTag: "1c7e65f"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Update `cxs-services` production image tag from `7b5f338` to `1c7e65f`

## Test plan
- [ ] Verify ArgoCD syncs cxs-services successfully
- [ ] Confirm cxs-services pods are running with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)