### PR TITLE
chore: update cxs-services image tag to 7c361ef in production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "1c7e65f"
+    newTag: "ff146f4"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Updates `cxs-services` production image tag from `1c7e65f` to `ff146f4`

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] cxs-services pods start with new image


Made with [Cursor](https://cursor.com)