### PR TITLE
chore: update cxs-services image tag to 0f62b09 in production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "cfffa9b"
+    newTag: "0f62b09"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Updates `cxs-services` production image tag to `0f62b09`

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] cxs-services pods start with new image


Made with [Cursor](https://cursor.com)