### PR TITLE
Deploy synmetrix load streaming to staging

### DIFF
--- a/data/synmetrix/overlays/staging/kustomization.yaml
+++ b/data/synmetrix/overlays/staging/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
   - name: quicklookup/synmetrix-cube
-    newTag: "b5c1883"
+    newTag: "7d54f27"
 
 namespace: synmetrix
 


### PR DESCRIPTION
## Summary
- update the staging Synmetrix Cube image tag to `7d54f27`
- deploy the semantic `/load` CSV and Arrow streaming changes to `synmetrix.contextsuite.dev` via ArgoCD

## Companion PR
- smartdataHQ/synmetrix#22

## Deployment
- ArgoCD staging watches `data/synmetrix/overlays/staging` on `main`
- once this PR merges, ArgoCD should sync the new `quicklookup/synmetrix-cube:7d54f27` image automatically