### PR TITLE
chore: move Azure OpenAI config from configmap to llm secret

### DIFF
--- a/apps/cxs-mimir-api/base/kustomization.yaml
+++ b/apps/cxs-mimir-api/base/kustomization.yaml
@@ -7,10 +7,7 @@ resources:
 configMapGenerator:
   - name: cxs-mimir-api-config
     literals:
-      - AZURE_DEPLOYMENT_NAME=gpt-4o
-      - AZURE_OPENAI_API_BASE=https://snjallgpt-swe.openai.azure.com/
       - AZURE_OPENAI_API_TYPE=azure
-      - AZURE_OPENAI_API_VERSION=2025-02-01-preview
       - BACKEND_BASE_URL=https://agents.contextsuite.com
       - CLICKHOUSE_HOST=10.180.122.32
       - CLICKHOUSE_PORT=8123

--- a/apps/cxs-mimir-api/base/mimir-api-deployment.yaml
+++ b/apps/cxs-mimir-api/base/mimir-api-deployment.yaml
@@ -44,11 +44,26 @@ spec:
             timeoutSeconds: 9
             failureThreshold: 6
           env:
-            - name: AZURE_OPENAI_API_KEY_NOT_USED
+            - name: AZURE_OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: llm
                   key: AZURE_OPENAI_API_KEY
+            - name: AZURE_DEPLOYMENT_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: llm
+                  key: AZURE_DEPLOYMENT_NAME
+            - name: AZURE_OPENAI_API_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: llm
+                  key: AZURE_OPENAI_BASE
+            - name: AZURE_OPENAI_API_VERSION
+              valueFrom:
+                secretKeyRef:
+                  name: llm
+                  key: AZURE_OPENAI_API_VERSION
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/apps/cxs-mimir-api/base/mimir-api-deployment.yaml
+++ b/apps/cxs-mimir-api/base/mimir-api-deployment.yaml
@@ -58,7 +58,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: llm
-                  key: AZURE_OPENAI_BASE
+                  key: AZURE_OPENAI_API_BASE
             - name: AZURE_OPENAI_API_VERSION
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- Moves `AZURE_DEPLOYMENT_NAME`, `AZURE_OPENAI_API_BASE`, and `AZURE_OPENAI_API_VERSION` from the configmap to `llm` secret refs in the deployment
- Renames `AZURE_OPENAI_API_KEY_NOT_USED` → `AZURE_OPENAI_API_KEY` (now active)
- Keeps `AZURE_OPENAI_API_TYPE=azure` in the configmap (not a secret)

## Note
The `llm` secret key for the base URL is `AZURE_OPENAI_BASE` (mapped to env var `AZURE_OPENAI_API_BASE`).

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] mimir-api pods start and pass readiness probes
- [ ] Verify Azure OpenAI calls work with the new secret-sourced config


Made with [Cursor](https://cursor.com)