### PR TITLE
chore: update cxs-mimir-api image tag to 1b20704 in production

### DIFF
--- a/apps/cxs-mimir-api/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-mimir-api
-    newTag: "b7c5fd8"
+    newTag: "1b20704"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Updates `cxs-mimir-api` production image tag to `1b20704`

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] cxs-mimir-api pods start with new image


Made with [Cursor](https://cursor.com)