### PR TITLE
chore: update cxs-services image tag to b0da7d9 in production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "b7c5fd8"
+    newTag: "b0da7d9"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Update `cxs-services` production image tag from `b7c5fd8` to `b0da7d9`

## Test plan
- [ ] ArgoCD auto-syncs and deploys the new image
- [ ] Verify cxs-services pods are running with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)