### PR TITLE
Remove public ingress for SSP

### DIFF
--- a/apps/ssp/overlays/production/kustomization.yaml
+++ b/apps/ssp/overlays/production/kustomization.yaml
@@ -10,4 +10,3 @@ images:
 resources:
   - ../../base
   - ssp-config.yaml
-  - ssp-ingress.yml


### PR DESCRIPTION
## Summary
- Removes the `admin.contextsuite.com` Ingress from SSP production overlay
- SSP will only be reachable internally at `ssp.api.svc.cluster.local:8080`
- CXS and Mimir services should use the internal FQDN instead of the public hostname

## Test plan
- [ ] Verify ArgoCD syncs and the Ingress resource is removed from the cluster
- [ ] Confirm CXS and Mimir can reach SSP via `http://ssp.api.svc.cluster.local:8080`
- [ ] Confirm `admin.contextsuite.com` is no longer accessible externally

🤖 Generated with [Claude Code](https://claude.com/claude-code)