### PR TITLE
Security: block admin ingress, remove hostPort from Neo4j and Keeper

### DIFF
--- a/apps/ssp/overlays/production/kustomization.yaml
+++ b/apps/ssp/overlays/production/kustomization.yaml
@@ -10,3 +10,4 @@ images:
 resources:
   - ../../base
   - ssp-config.yaml
+  - ssp-block-ingress.yml

--- a/apps/ssp/overlays/production/ssp-block-ingress.yml
+++ b/apps/ssp/overlays/production/ssp-block-ingress.yml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ssp-block
+  annotations:
+    nginx.ingress.kubernetes.io/server-snippet: |
+      return 444;
+spec:
+  rules:
+    - host: admin.contextsuite.com
+  tls:
+    - hosts:
+        - admin.contextsuite.com
+      secretName: admin-contextsuite-com-tls

--- a/data/keeper/base/keeper-stateful.yaml
+++ b/data/keeper/base/keeper-stateful.yaml
@@ -62,9 +62,7 @@ spec:
         image: clickhouse/clickhouse-keeper:24.3.2.23-alpine
         ports:
         - containerPort: 9181
-          hostPort: 9181
         - containerPort: 9234
-          hostPort: 9234
         command: [ "/bin/bash", "-c"]
         args: [ "IFS=- read -r var1 var2 <<< $HOSTNAME ; echo 'Custom Entrypoint' ; echo $var2 ; declare -x PODNR=$var2 ; /entrypoint.sh" ]
         volumeMounts:

--- a/data/neo4j/overlays/production/neo4j-stateful.yaml
+++ b/data/neo4j/overlays/production/neo4j-stateful.yaml
@@ -57,9 +57,7 @@ spec:
           image: neo4j:5-enterprise
           ports:
             - containerPort: 7474
-              hostPort: 7474
             - containerPort: 7687
-              hostPort: 7687
           volumeMounts:
             - name: neo4j
               mountPath: /data

--- a/data/neo4j/overlays/staging/neo4j-stateful.yaml
+++ b/data/neo4j/overlays/staging/neo4j-stateful.yaml
@@ -57,9 +57,7 @@ spec:
           image: neo4j:5-enterprise
           ports:
             - containerPort: 7474
-              hostPort: 7474
             - containerPort: 7687
-              hostPort: 7687
           volumeMounts:
             - name: neo4j
               mountPath: /data


### PR DESCRIPTION
## Summary
- Add blocking ingress for `admin.contextsuite.com` that returns nginx 444 (silent connection drop) instead of default 404
- Remove `hostPort` bindings from Neo4j (7474, 7687) in both production and staging — access remains via Tailscale and ClusterIP
- Remove `hostPort` bindings from ClickHouse Keeper (9181, 9234) — Raft consensus already uses internal FQDNs via headless service

## Test plan
- [ ] Verify `admin.contextsuite.com` silently drops connections (no 404 page)
- [ ] Confirm Neo4j is reachable via Tailscale after pod restart
- [ ] Confirm ClickHouse Keeper Raft consensus remains healthy after pod rollout
- [ ] Verify Neo4j ports 7474/7687 are no longer accessible on node IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)