### PR TITLE
Expose SSP admin via Tailscale

### DIFF
--- a/apps/ssp/base/ssp-service.yaml
+++ b/apps/ssp/base/ssp-service.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: ssp
     tier: api
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: apps-ssp
 spec:
   type: ClusterIP
   sessionAffinity: ClientIP


### PR DESCRIPTION
## Summary
- Add `tailscale.com/expose` and `tailscale.com/hostname: apps-ssp` annotations to SSP service
- SSP admin is now accessible at `apps-ssp:8080` on the Tailscale network
- Replaces the public `admin.contextsuite.com` ingress removed in #62

## Test plan
- [ ] Verify SSP appears as `apps-ssp` on the Tailscale network after sync
- [ ] Confirm `http://apps-ssp:8080` is reachable from a Tailscale-connected device

🤖 Generated with [Claude Code](https://claude.com/claude-code)