### PR TITLE
chore: update cxs-services image tag to 672ee8a

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "f212650"
+    newTag: "672ee8a"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Updates `cxs-services` production image tag from `f212650` to `672ee8a`

## Test plan
- [ ] ArgoCD auto-syncs and deployment rolls out successfully
- [ ] Verify cxs-services pods are healthy after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)