### PR TITLE
chore: add 172.23.128.1 to ssp ingress IP whitelist

### DIFF
--- a/apps/ssp/overlays/production/ssp-ingress.yml
+++ b/apps/ssp/overlays/production/ssp-ingress.yml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32,172.23.128.1/32"
     nginx.ingress.kubernetes.io/custom-http-errors: "403"
     nginx.ingress.kubernetes.io/server-snippet: |
       error_page 403 =444 /;


### PR DESCRIPTION
## Summary
- Adds `172.23.128.1/32` to the nginx ingress whitelist for `admin.contextsuite.com`

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] Access to admin.contextsuite.com works from 172.23.128.1


Made with [Cursor](https://cursor.com)