### PR TITLE
Fix SSP ingress: remove server-snippet causing 404

### DIFF
--- a/apps/ssp/overlays/production/ssp-ingress.yml
+++ b/apps/ssp/overlays/production/ssp-ingress.yml
@@ -6,9 +6,6 @@ metadata:
     ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32,172.23.128.1/32"
-    nginx.ingress.kubernetes.io/custom-http-errors: "403"
-    nginx.ingress.kubernetes.io/server-snippet: |
-      error_page 403 =444 /;
 spec:
   rules:
     - host: admin.contextsuite.com


### PR DESCRIPTION
## Summary
- Remove `server-snippet` and `custom-http-errors` annotations from SSP ingress
- These annotations are rejected by nginx ingress controller v1.9+ (snippets disabled by default)
- This was preventing the ingress from being created, resulting in a 404
- Whitelist still works: only `194.144.179.29` and `172.23.128.1` can access SSP
- Non-whitelisted IPs will get a 403 instead of a silent drop

## Test plan
- [ ] Verify `admin.contextsuite.com` is accessible from whitelisted IPs
- [ ] Verify non-whitelisted IPs get 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)