### PR TITLE
chore: replace 172.23.128.1 with 82.221.53.180 in ssp ingress whitelist

### DIFF
--- a/apps/ssp/overlays/production/ssp-ingress.yml
+++ b/apps/ssp/overlays/production/ssp-ingress.yml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32,172.23.128.1/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32,82.221.53.180/32"
 spec:
   rules:
     - host: admin.contextsuite.com


### PR DESCRIPTION
## Summary
- Replaces `172.23.128.1/32` with `82.221.53.180/32` in the ssp ingress IP whitelist (the actual public NAT IP)

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] Access to admin.contextsuite.com works from 82.221.53.180


Made with [Cursor](https://cursor.com)