### PR TITLE
fix: add CORS annotations to ssp ingress for skattur.is domains

### DIFF
--- a/apps/ssp/overlays/production/ssp-ingress.yml
+++ b/apps/ssp/overlays/production/ssp-ingress.yml
@@ -6,6 +6,10 @@ metadata:
     ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32,82.221.53.180/32"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://zenobia.skattur.is,https://chat.skattur.is,https://huginn.skattur.is"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "Authorization, Content-Type"
 spec:
   rules:
     - host: admin.contextsuite.com


### PR DESCRIPTION
## Summary
- Adds CORS annotations to the ssp ingress so browser requests from `zenobia.skattur.is`, `chat.skattur.is`, and `huginn.skattur.is` can reach `admin.contextsuite.com`
- The mimir-ui makes cross-origin API calls to `/api/dialogue` and `/api/dialogue_theme`. Without CORS config, nginx rejects the browser's preflight OPTIONS requests with 403

## Changes
```yaml
nginx.ingress.kubernetes.io/enable-cors: "true"
nginx.ingress.kubernetes.io/cors-allow-origin: "https://zenobia.skattur.is,https://chat.skattur.is,https://huginn.skattur.is"
nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, OPTIONS"
nginx.ingress.kubernetes.io/cors-allow-headers: "Authorization, Content-Type"
```

## Impact
- No effect on direct access to `admin.contextsuite.com` (same-origin, CORS not triggered)
- No effect on internal cluster traffic (doesn't go through ingress)
- Only activates for cross-origin requests from the listed skattur.is domains

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] Browser requests from zenobia.skattur.is to admin.contextsuite.com/api/dialogue no longer get CORS 403
- [ ] Preflight OPTIONS requests return 204 with correct Access-Control-Allow-* headers
- [ ] Direct access to admin.contextsuite.com still works as before


Made with [Cursor](https://cursor.com)