### PR TITLE
fix: add DELETE to CORS allowed methods for ssp ingress

### DIFF
--- a/apps/ssp/overlays/production/ssp-ingress.yml
+++ b/apps/ssp/overlays/production/ssp-ingress.yml
@@ -8,7 +8,7 @@ metadata:
     nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32,82.221.53.180/32"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "https://zenobia.skattur.is,https://chat.skattur.is,https://huginn.skattur.is"
-    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, DELETE, OPTIONS"
     nginx.ingress.kubernetes.io/cors-allow-headers: "Authorization, Content-Type"
 spec:
   rules:


### PR DESCRIPTION
## Summary
- Adds `DELETE` to the CORS allowed methods for ssp ingress (was missing from #77)

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] DELETE requests from skattur.is domains to admin.contextsuite.com work


Made with [Cursor](https://cursor.com)