### PR TITLE
chore: add 82.221.53.156 to ssp ingress IP whitelist

### DIFF
--- a/apps/ssp/overlays/production/ssp-ingress.yml
+++ b/apps/ssp/overlays/production/ssp-ingress.yml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32,82.221.53.180/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32,82.221.53.180/32,82.221.53.156/32"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "https://zenobia.skattur.is,https://chat.skattur.is,https://huginn.skattur.is"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, DELETE, OPTIONS"


### PR DESCRIPTION
## Summary
- Adds `82.221.53.156/32` to the ssp ingress IP whitelist

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] Access to admin.contextsuite.com works from 82.221.53.156


Made with [Cursor](https://cursor.com)