### PR TITLE
chore: update cxs-mimir-api image tag to 3f3496d in production

### DIFF
--- a/apps/cxs-mimir-api/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-mimir-api
-    newTag: "9654764"
+    newTag: "3f3496d"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Updates `cxs-mimir-api` production image tag to `3f3496d`

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] cxs-mimir-api pods start with new image


Made with [Cursor](https://cursor.com)