### PR TITLE
chore: whitelist IP 46.182.188.110 in SSP ingress

### DIFF
--- a/apps/ssp/overlays/production/ssp-ingress.yml
+++ b/apps/ssp/overlays/production/ssp-ingress.yml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32,82.221.53.180/32,82.221.53.156/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32,82.221.53.180/32,82.221.53.156/32,46.182.188.110/32"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "https://zenobia.skattur.is,https://chat.skattur.is,https://huginn.skattur.is"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, DELETE, OPTIONS"


### PR DESCRIPTION
## Summary
- Add IP `46.182.188.110/32` to the nginx whitelist-source-range annotation for the SSP production ingress (`admin.contextsuite.com`)

## Test plan
- [ ] Verify kustomize build passes: `kubectl kustomize apps/ssp/overlays/production`
- [ ] After ArgoCD sync, confirm access to `admin.contextsuite.com` from the whitelisted IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)