### PR TITLE
chore: update cxs-services image tag to cc65e9c in production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "06f0e23"
+    newTag: "cc65e9c"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Updates `cxs-services` production image tag from `06f0e23` to `cc65e9c`

## Test plan
- [ ] Verify ArgoCD picks up the new image tag and syncs successfully
- [ ] Confirm cxs-services pods are running with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)