### PR TITLE
chore: revert cxs-services image tag to 06f0e23 in production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "cc65e9c"
+    newTag: "06f0e23"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Reverts `cxs-services` production image tag from `cc65e9c` back to `06f0e23`

## Test plan
- [ ] Verify ArgoCD syncs and rolls back to the previous image
- [ ] Confirm cxs-services pods are running with tag `06f0e23`

🤖 Generated with [Claude Code](https://claude.com/claude-code)