### PR TITLE
chore: update cxs-services image tag to 5f9fe04 in production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "06f0e23"
+    newTag: "5f9fe04"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Update `cxs-services` production image tag from `06f0e23` to `5f9fe04`

## Test plan
- [ ] Verify ArgoCD syncs the new image tag successfully
- [ ] Confirm cxs-services pods are running with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)