### PR TITLE
chore: update cxs-services image tag to 0dbce51

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "af0514b"
+    newTag: "0dbce51"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Update cxs-services production image tag from `af0514b` to `0dbce51`

## Test plan
- [ ] Verify ArgoCD picks up the new image tag and syncs successfully
- [ ] Confirm cxs-services pods are running with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)