### PR TITLE
chore: update cxs-services image tag to bccfd70

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "af0514b"
+    newTag: "bccfd70"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Update cxs-services production image tag from `af0514b` to `bccfd70`

## Test plan
- [ ] ArgoCD auto-syncs the new image tag
- [ ] Verify cxs-services pods are running with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)