### PR TITLE
chore: update cxs-services image tag to eb3a97a in production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "bccfd70"
+    newTag: "eb3a97a"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Update cxs-services production image tag from `bccfd70` to `eb3a97a`

## Test plan
- [ ] ArgoCD auto-syncs the new image tag within ~3 minutes
- [ ] Verify cxs-services pods are running with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)