### PR TITLE
chore: update cxs-services image tag to bf0b2ff in production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "eb3a97a"
+    newTag: "bf0b2ff"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Updates `cxs-services` production image tag to `bf0b2ff`

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] cxs-services pods start with new image


Made with [Cursor](https://cursor.com)