### PR TITLE
chore: update cxs-services image tag to d2b8149 in production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "bf0b2ff"
+    newTag: "d2b8149"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Updates `cxs-services` production image tag to `d2b8149`

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] cxs-services pods start with new image


Made with [Cursor](https://cursor.com)