### PR TITLE
chore: update cxs-mimir-api to d6aa6a1 and cxs-services to a7e9e9a in production

### DIFF
--- a/apps/cxs-mimir-api/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-mimir-api
-    newTag: "5b8a1ea"
+    newTag: "d6aa6a1"
 
 resources:
   - ../../base

--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "bf0b2ff"
+    newTag: "a7e9e9a"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Updates `cxs-mimir-api` production image tag to `d6aa6a1`
- Updates `cxs-services` production image tag to `a7e9e9a`

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] Both services start with new images


Made with [Cursor](https://cursor.com)