### PR TITLE
chore: update cxs-services image tag to 4d7782c in production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "d901de8"
+    newTag: "4d7782c"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Updates `cxs-services` production image tag from `d901de8` to `4d7782c`

## Test plan
- [ ] ArgoCD auto-syncs the new image tag
- [ ] Verify cxs-services pods are healthy after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)