### PR TITLE
chore: update mimir-api image tag to 85b065a in production

### DIFF
--- a/apps/mimir-api/overlays/production/kustomization.yaml
+++ b/apps/mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/mimir-api
-    newTag: 6709a50
+    newTag: 85b065a
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Updates `mimir-api` production image tag to `85b065a`

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] mimir-api pods start with new image


Made with [Cursor](https://cursor.com)