### PR TITLE
chore: update mimir-api image tag to 0e49e77 in production

### DIFF
--- a/apps/mimir-api/overlays/production/kustomization.yaml
+++ b/apps/mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/mimir-api
-    newTag: 85b065a
+    newTag: 0e49e77
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Updates `mimir-api` production image tag to `0e49e77`

## Test plan
- [ ] ArgoCD syncs successfully after merge
- [ ] mimir-api pods start with new image


Made with [Cursor](https://cursor.com)