### PR TITLE
chore(production): cxs-services 0b0228b + SSP whitelist 84.159.134.1

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "c350aa3"
+    newTag: "0b0228b"
 
 resources:
   - ../../base

--- a/apps/ssp/overlays/production/ssp-ingress.yml
+++ b/apps/ssp/overlays/production/ssp-ingress.yml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32,82.221.53.180/32,82.221.53.156/32,46.182.188.110/32,153.92.144.10/32,89.160.219.76/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32,82.221.53.180/32,82.221.53.156/32,46.182.188.110/32,153.92.144.10/32,84.159.134.1/32"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "https://zenobia.skattur.is,https://chat.skattur.is,https://huginn.skattur.is"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, DELETE, OPTIONS"


### PR DESCRIPTION
## Summary

- **cxs-services (production):** bump `quicklookup/cxs-services` image tag from `c350aa3` to `0b0228b` (`apps/cxs-services/overlays/production/kustomization.yaml`).
- **SSP ingress (production):** update `nginx.ingress.kubernetes.io/whitelist-source-range` for `admin.contextsuite.com`: replace `89.160.219.76/32` with `84.159.134.1/32` (`apps/ssp/overlays/production/ssp-ingress.yml`).

## Verification

- [ ] ArgoCD / deploy pipeline picks up overlay changes as expected
- [ ] Confirm new whitelist IP is correct for the intended client/network

Made with [Cursor](https://cursor.com)