### PR TITLE
fix(postgres): bump backup deadlines, expand repo1 PVC, tighten repo2 retention

### DIFF
--- a/data/postgres/base/backup-jobs/backup-cronjobs-minio.yaml
+++ b/data/postgres/base/backup-jobs/backup-cronjobs-minio.yaml
@@ -17,7 +17,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 3600  # 1 hour timeout
+      activeDeadlineSeconds: 7200  # 2 hour timeout (full ~45min observed)
       template:
         metadata:
           labels:
@@ -76,7 +76,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 1800  # 30 minutes timeout
+      activeDeadlineSeconds: 5400  # 90 min timeout (diff ~30min observed)
       template:
         metadata:
           labels:

--- a/data/postgres/base/backup-jobs/backup-cronjobs-repo1.yaml
+++ b/data/postgres/base/backup-jobs/backup-cronjobs-repo1.yaml
@@ -17,7 +17,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 3600  # 1 hour timeout
+      activeDeadlineSeconds: 7200  # 2 hour timeout (full ~45min observed)
       template:
         metadata:
           labels:
@@ -76,7 +76,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 1800  # 30 minutes timeout
+      activeDeadlineSeconds: 5400  # 90 min timeout (diff ~30min observed)
       template:
         metadata:
           labels:

--- a/data/postgres/overlays/production/postgres-minio-backup.yaml
+++ b/data/postgres/overlays/production/postgres-minio-backup.yaml
@@ -10,10 +10,10 @@ spec:
             name: postgres-minio-backup-credentials
       global:
         # Configuration for "repo2" (MinIO S3)
-        repo2-retention-full: "8"       # Keep more backups offsite
+        repo2-retention-full: "4"       # 4 weekly fulls (Apr 21: reduced from 8 after MinIO-full incident)
         repo2-retention-full-type: count
-        repo2-retention-archive: "4"
-        repo2-retention-diff: "14"
+        repo2-retention-archive: "2"
+        repo2-retention-diff: "7"
         repo2-s3-uri-style: path         # Required for MinIO
         repo2-storage-verify-tls: "n"      # Use HTTP instead of HTTPS
       repos:
@@ -27,7 +27,7 @@ spec:
                 - ReadWriteOnce
               resources:
                 requests:
-                  storage: 300Gi
+                  storage: 1000Gi  # Apr 21: bumped from 300Gi (live was 500Gi via manual expand) to absorb WAL growth
         - name: repo2
           schedules:
             full: "0 2 * * 6"      # Saturday 02:00 (offset from repo1)


### PR DESCRIPTION
## Context
Apr 21 incident: repo1 Longhorn PVC filled (live 500 Gi vs declared 300 Gi) → WAL archive-push to repo2 MinIO broke → primary `pg_wal` accumulated. Applied live: retention cuts (~129 GB freed), Tier 1 Longhorn cleanup (~716 GB freed). This PR codifies the sustainable settings so drift doesn't recur.

## Changes
- **CronJob `activeDeadlineSeconds`**: full 3600 → 7200, diff 1800 → 5400. Healthy runs observed at 28–45 min since the Apr 14 cluster upgrade; the old tight deadlines were silently killing jobs via `DeadlineExceeded`.
- **repo1 PVC**: 300 Gi → 1000 Gi (live was 500 Gi via manual expansion; Git was out of sync). Accommodates ~40 GB/day WAL + retention + margin.
- **repo2 retention**: `retention-full` 8 → 4, `retention-diff` 14 → 7, `retention-archive` 4 → 2. Matches what was applied live via `pgbackrest expire`. PITR window: 4 weekly restore points + ~14 days continuous.

## Verify post-merge
1. ArgoCD syncs within ~3 min.
2. Longhorn online-expands repo1 PVC 500 → 1000 Gi (no downtime, no pod restart).
3. Next scheduled CronJob run completes inside the new deadlines.

## Out of scope (separate tracks)
- pgBackRest upgrade — not needed (99.9% pipe_w hang fixed operationally by yesterday's `cxs-pg-repo-host-0` pod restart).
- `rvfc-0` replica reinit (TL 24 vs 28 divergence from Apr 14 upgrade).
- Grafana metrics backend (dead Prometheus datasource since Rancher Monitoring removal).
- MinIO admin-side cleanup (`mc rm --recursive` for empty-shell prefixes, `mc admin info` for capacity visibility) — for Gissur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)