### PR TITLE
chore(production): bump cxs-services to f9b4907

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "752c910"
+    newTag: "f9b4907"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary

Bumps `quicklookup/cxs-services` image tag from `752c910` to `f9b4907` in `apps/cxs-services/overlays/production/kustomization.yaml`.

Made with [Cursor](https://cursor.com)