### PR TITLE
feat(cxs-services): expose via ingress with Cyclr IP allowlist

### DIFF
--- a/apps/cxs-services/base/cxs-services-ingress.yaml
+++ b/apps/cxs-services/base/cxs-services-ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cxsservices
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/whitelist-source-range: "18.185.231.228/32,3.77.48.46/32,3.74.172.161/32,52.56.244.97/32,3.11.48.73/32,18.135.73.241/32,52.22.119.215/32,3.225.94.137/32,52.87.43.241/32,54.165.179.173/32,34.226.81.206/32,52.6.81.143/32,3.20.212.11/32,3.131.146.218/32,3.17.34.135/32"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: cxs-utils.contextsuite.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: cxsservices
+                port:
+                  number: 8088
+  tls:
+    - hosts:
+        - cxs-utils.contextsuite.com
+      secretName: cxs-utils-contextsuite-com-tls

--- a/apps/cxs-services/base/kustomization.yaml
+++ b/apps/cxs-services/base/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - cxs-services-service.yaml
   - cxs-services-volumes.yaml
   - cxs-services-config.yaml
+  - cxs-services-ingress.yaml
 transformers:
   - add-version-label.yaml


### PR DESCRIPTION
## Summary
- Adds public `Ingress` at `cxs-utils.contextsuite.com` → existing `cxsservices` NodePort (port 8088).
- Restricts access via nginx `whitelist-source-range` annotation to Cyclr's 15 egress IPs (EU + US regions).
- TLS via cert-manager `letsencrypt-prod` ClusterIssuer (new secret `cxs-utils-contextsuite-com-tls`).

## Why
Cyclr cannot resolve in-cluster DNS (`cxsservices.solutions:8088`) and is not on our Tailnet. Without a public entrypoint, Cyclr Step Scripts that need to call the CXS utility API (Blue Car Email Drafts cycle, etc.) fail at DNS resolution. IP allowlisting keeps the surface to Cyclr-only so the existing write-key-in-URL pattern stays safe.

## Test plan
- [ ] ArgoCD auto-syncs `apps-cxs-services` within ~3 min of merge
- [ ] `kubectl get ingress -n solutions cxsservices` shows the ingress with the 3 LB IPs
- [ ] `kubectl get certificate -n solutions cxs-utils-contextsuite-com-tls` reaches `Ready=True`
- [ ] From a non-Cyclr IP (e.g. my laptop): `curl -sI https://cxs-utils.contextsuite.com/` returns **403** (allowlist working)
- [ ] From Cyclr: rerun the probe cycle — Verify Event step reaches the backend (no more DNS error, 2xx/4xx from the app, not from nginx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)