### PR TITLE
chore(production): bump cxs-services to 3b366fd

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "f9b4907"
+    newTag: "3b366fd"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary

Bumps `quicklookup/cxs-services` image tag from `f9b4907` to `3b366fd` in `apps/cxs-services/overlays/production/kustomization.yaml`.

Made with [Cursor](https://cursor.com)