### PR TITLE
chore(production): bump cxs-mimir-api image to 3b235fa

### DIFF
--- a/apps/cxs-mimir-api/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-mimir-api
-    newTag: "112bfe1"
+    newTag: "3b235fa"
 
 resources:
   - ../../base


### PR DESCRIPTION
Updates the `quicklookup/cxs-mimir-api` production image tag in the Kustomize overlay to `3b235fa`.

Made with [Cursor](https://cursor.com)