### PR TITLE
chore(production): bump cxs-mimir-api image to f4accb0

### DIFF
--- a/apps/cxs-mimir-api/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-mimir-api
-    newTag: "3b235fa"
+    newTag: "f4accb0"
 
 resources:
   - ../../base


### PR DESCRIPTION
Sets `quicklookup/cxs-mimir-api` production image `newTag` to `f4accb0` in the Kustomize overlay.

Made with [Cursor](https://cursor.com)