### PR TITLE
chore(production): bump cxs-services image to 575059e

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "b264a48"
+    newTag: "575059e"
 
 resources:
   - ../../base


### PR DESCRIPTION
Sets `quicklookup/cxs-services` production image `newTag` to `575059e`.

Made with [Cursor](https://cursor.com)