### PR TITLE
chore(production): bump cxs-services image to 986d96a

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "84146c8"
+    newTag: "986d96a"
 
 resources:
   - ../../base


### PR DESCRIPTION
Sets `quicklookup/cxs-services` production image `newTag` to `986d96a`.

Made with [Cursor](https://cursor.com)