### PR TITLE
chore(production): bump cxs-services image to 9fabcf2

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "1b34f06"
+    newTag: "9fabcf2"
 
 resources:
   - ../../base


### PR DESCRIPTION
Sets `quicklookup/cxs-services` production image `newTag` to `9fabcf2`.

Made with [Cursor](https://cursor.com)