### PR TITLE
chore(production): bump cxs-services image to 39d0733

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "9fabcf2"
+    newTag: "39d0733"
 
 resources:
   - ../../base


### PR DESCRIPTION
Sets `quicklookup/cxs-services` production image `newTag` to `39d0733`.

Made with [Cursor](https://cursor.com)