### PR TITLE
chore(production): bump cxs-mimir-api image to 231b35c

### DIFF
--- a/apps/cxs-mimir-api/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-mimir-api
-    newTag: "76b5ae3"
+    newTag: "231b35c"
 
 resources:
   - ../../base


### PR DESCRIPTION
Sets `quicklookup/cxs-mimir-api` production image `newTag` to `231b35c`.

Made with [Cursor](https://cursor.com)