### PR TITLE
chore(production): bump cxs-mimir-api image to 1209cab

### DIFF
--- a/apps/cxs-mimir-api/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-mimir-api
-    newTag: "231b35c"
+    newTag: "1209cab"
 
 resources:
   - ../../base


### PR DESCRIPTION
Sets `quicklookup/cxs-mimir-api` production image `newTag` to `1209cab`.

Made with [Cursor](https://cursor.com)