### PR TITLE
chore(production): bump cxs-services image to 6401e42

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "15c67d7"
+    newTag: "6401e42"
 
 resources:
   - ../../base


### PR DESCRIPTION
Sets `quicklookup/cxs-services` production image `newTag` to `6401e42`.

Made with [Cursor](https://cursor.com)