### PR TITLE
chore(production): bump cxs-services image to e132a13

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "6401e42"
+    newTag: "e132a13"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Bump `quicklookup/cxs-services` production image tag from `6401e42` to `e132a13`.

## Test plan
- [ ] ArgoCD syncs `apps-cxs-services` successfully
- [ ] cxs-services pods roll out healthy in `solutions` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)