### PR TITLE
chore(production): bump cxs-services image to 73e6777

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "e132a13"
+    newTag: "73e6777"
 
 resources:
   - ../../base


### PR DESCRIPTION
Sets `quicklookup/cxs-services` production image `newTag` to `73e6777`.

Made with [Cursor](https://cursor.com)