### PR TITLE
chore(ssp): whitelist 84.159.134.230 on production ingress

### DIFF
--- a/apps/ssp/overlays/production/ssp-ingress.yml
+++ b/apps/ssp/overlays/production/ssp-ingress.yml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32,82.221.53.180/32,82.221.53.156/32,46.182.188.110/32,153.92.144.10/32,84.159.134.1/32,157.157.245.130/32"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "194.144.179.29/32,82.221.53.180/32,82.221.53.156/32,46.182.188.110/32,153.92.144.10/32,84.159.134.1/32,84.159.134.230/32,157.157.245.130/32"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "https://zenobia.skattur.is,https://chat.skattur.is,https://huginn.skattur.is"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, DELETE, OPTIONS"


### PR DESCRIPTION
## Summary
- Adds `84.159.134.230/32` to the SSP production ingress IP whitelist.

## Test plan
- [ ] After merge and ArgoCD sync, confirm access to `admin.contextsuite.com` from `84.159.134.230`

Made with [Cursor](https://cursor.com)