### PR TITLE
migrate OpenAI Realtime API from Beta to GA

### DIFF
--- a/apps/cxs-mimir-api/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-mimir-api
-    newTag: "a8e8d50"
+    newTag: "cbbdeee"
 
 resources:
   - ../../base


### PR DESCRIPTION
Migrates voice streaming from the deprecated OpenAI Realtime Beta API (client.beta.realtime) to the GA endpoint (client.realtime)