### PR TITLE
fix(redis): relax replica probes + right-size requests in prod overlay

### DIFF
--- a/data/redis/overlays/production/kustomization.yaml
+++ b/data/redis/overlays/production/kustomization.yaml
@@ -1,2 +1,55 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
   - ../../base
+
+# Production data set is ~4.8GB / 1.4M keys. A replica restart triggers a full
+# diskless resync that, with the chart's default probes, gets SIGTERMed mid-sync
+# (liveness initialDelay 20s / 5x5s, and it pings the master too) -> CrashLoopBackOff.
+# Relax the replica probes to cover AOF load + full resync, and right-size requests
+# to observed usage so the scheduler stops under-counting Redis.
+patches:
+  - target:
+      kind: StatefulSet
+      name: redis-replicas
+    patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: redis-replicas
+      spec:
+        template:
+          spec:
+            containers:
+              - name: redis
+                startupProbe:
+                  failureThreshold: 60
+                livenessProbe:
+                  initialDelaySeconds: 120
+                  periodSeconds: 10
+                  failureThreshold: 10
+                readinessProbe:
+                  initialDelaySeconds: 30
+                  failureThreshold: 10
+                resources:
+                  requests:
+                    memory: 6Gi
+                    cpu: "1"
+  - target:
+      kind: StatefulSet
+      name: redis-master
+    patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: redis-master
+      spec:
+        template:
+          spec:
+            containers:
+              - name: redis
+                resources:
+                  requests:
+                    memory: 6Gi
+                    cpu: "1"

--- a/data/redis/overlays/production/kustomization.yaml
+++ b/data/redis/overlays/production/kustomization.yaml
@@ -4,11 +4,28 @@ kind: Kustomization
 resources:
   - ../../base
 
-# Production data set is ~4.8GB / 1.4M keys. A replica restart triggers a full
-# diskless resync that, with the chart's default probes, gets SIGTERMed mid-sync
-# (liveness initialDelay 20s / 5x5s, and it pings the master too) -> CrashLoopBackOff.
-# Relax the replica probes to cover AOF load + full resync, and right-size requests
-# to observed usage so the scheduler stops under-counting Redis.
+# Production data set is ~4.8GB / 1.4M keys. With the chart defaults this cluster
+# fell into a replica resync death spiral:
+#   1. A replica restart forces a full diskless resync (~90s) from the master.
+#   2. The chart's liveness probe (ping_liveness_local_AND_master, 20s / 5x5s)
+#      pings the MASTER. During resync the master is busy forking/streaming the
+#      4.8GB RDB to every replica (and its headless DNS blips on restart), so the
+#      probe times out and the replica is SIGTERMed mid-transfer.
+#   3. The dropped socket aborts the master's shared diskless fork -> all replicas
+#      re-request a full resync -> self-sustaining storm that also flapped the master.
+#
+# Fix, scoped to production (staging has small data + smaller nodes):
+#   - liveness -> LOCAL-ONLY on both master and replicas. A node's liveness must
+#     never depend on the master being responsive; replica readiness still pings the
+#     master so an unsynced replica stays out of rotation without being killed.
+#   - relax startup/liveness/readiness timing to cover AOF load + full resync.
+#   - requests sized to observed usage (~4.8GB / ~1 core). Requests only, no hard
+#     memory limit or maxmemory: the data set grows and a hard cap would trade this
+#     crash loop for OOMKill / silent eviction of session+conversation keys. That
+#     ceiling is a separate decision.
+#
+# Probes are spelled out in full (not partial merges) so the rendered manifests
+# equal the running, validated cluster config exactly.
 patches:
   - target:
       kind: StatefulSet
@@ -24,13 +41,34 @@ patches:
             containers:
               - name: redis
                 startupProbe:
+                  tcpSocket:
+                    port: redis
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  successThreshold: 1
                   failureThreshold: 60
                 livenessProbe:
+                  exec:
+                    command:
+                      - sh
+                      - -c
+                      - /health/ping_liveness_local.sh 5
                   initialDelaySeconds: 120
                   periodSeconds: 10
+                  timeoutSeconds: 6
+                  successThreshold: 1
                   failureThreshold: 10
                 readinessProbe:
+                  exec:
+                    command:
+                      - sh
+                      - -c
+                      - /health/ping_readiness_local_and_master.sh 1
                   initialDelaySeconds: 30
+                  periodSeconds: 5
+                  timeoutSeconds: 2
+                  successThreshold: 1
                   failureThreshold: 10
                 resources:
                   requests:
@@ -49,6 +87,36 @@ patches:
           spec:
             containers:
               - name: redis
+                startupProbe:
+                  tcpSocket:
+                    port: redis
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  successThreshold: 1
+                  failureThreshold: 60
+                livenessProbe:
+                  exec:
+                    command:
+                      - sh
+                      - -c
+                      - /health/ping_liveness_local.sh 5
+                  initialDelaySeconds: 120
+                  periodSeconds: 10
+                  timeoutSeconds: 6
+                  successThreshold: 1
+                  failureThreshold: 10
+                readinessProbe:
+                  exec:
+                    command:
+                      - sh
+                      - -c
+                      - /health/ping_readiness_local.sh 1
+                  initialDelaySeconds: 30
+                  periodSeconds: 5
+                  timeoutSeconds: 2
+                  successThreshold: 1
+                  failureThreshold: 10
                 resources:
                   requests:
                     memory: 6Gi


### PR DESCRIPTION
## Problem (2026-05-29 prod incident)

`data/redis` (Bitnami redis 19.0.1, ~4.8 GB / 1.4M keys) fell into a replica resync **death spiral**:

1. A replica restart forces a full diskless resync (~90s) from the master.
2. The chart's **liveness** probe is `ping_liveness_local_and_master.sh` — it pings the **master**. During resync the master is busy forking/streaming the 4.8 GB RDB to every replica (and its headless DNS blips on restart), so the probe times out → the otherwise-healthy replica is **SIGTERMed mid-transfer** (exit 0).
3. The dropped socket aborts the master's shared diskless fork → all replicas re-request a full resync. The constant forking then froze the master's main thread enough that the **master** failed its own liveness too → self-amplifying storm.

Confirmed not storage, not OOM, not DNS/NetworkPolicy/CNI — purely the liveness-on-master dependency.

## Fix (scoped to the production overlay)

- **liveness → LOCAL-ONLY on both master and replicas** (`ping_liveness_local.sh`). A node's liveness must never depend on the master being reachable. **This is the core fix.**
- **replica readiness still pings the master** (keeps an unsynced replica out of rotation without killing it); master readiness is local-only.
- relaxed startup/liveness/readiness timing to cover AOF load (~20–34s) + full resync.
- requests right-sized: master `2Gi/100m` and replica `4Gi/500m` → both **`6Gi/1cpu`** (observed usage ~4.8 GB / ~1 core). Requests only — no hard memory limit / `maxmemory` (dataset grows; a hard cap would trade this crash loop for OOMKill or silent eviction of session+conversation keys — a separate decision).

Probes are written out in full because the master has no base `startupProbe`, so a partial merge would yield an invalid handler-less probe.

## Validation

- `kubectl kustomize --enable-helm data/redis/overlays/production` renders both StatefulSets **field-for-field identical to the running, stabilized cluster** (the config that ended the incident). So once merged, the Argo sync is a **no-op — no rolling restart**.
- The fix was applied live during the incident and the cluster has been stable since (master + 3 replicas `1/1`, 0 restarts).

> Note: Argo auto-sync for `data-redis` was temporarily paused during the incident (self-heal kept reverting the live patch). **Re-enable it after this merges** (restore `syncPolicy.automated` on the Application and remove the `ignoreApplicationDifferences` entry on ApplicationSet `appset-data`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
