### PR TITLE
Disable taskCreationCheck in livenessProbe

### DIFF
--- a/pipelines/airflow/overlays/production/values.yaml
+++ b/pipelines/airflow/overlays/production/values.yaml
@@ -283,7 +283,7 @@ scheduler:
   livenessProbe:
     enabled: true
     taskCreationCheck:
-      enabled: true
+      enabled: false
       thresholdSeconds: 300
       schedulerAgeBeforeCheck: 180
 web:


### PR DESCRIPTION
Idle gaps between batch DAG runs are normal here; the 300s LocalTaskJob
check was restarting a healthy scheduler every ~6 minutes and blocking
scheduling. Heartbeat-based liveness remains enabled.