### PR TITLE
chore(production): bump cxs-services and mimir-chat image tags

### DIFF
--- a/apps/cxs-mimir-chat/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-chat/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/mimir-chat
-    newTag: 8f54f3e
+    newTag: 15f5992
 
 # Production configs reside in the base
 resources:

--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "73e6777"
+    newTag: "3ddea35"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary

- **cxs-services:** `quicklookup/cxs-services` `73e6777` → `3ddea35` (`apps/cxs-services/overlays/production/kustomization.yaml`)
- **mimir-chat:** `quicklookup/mimir-chat` `8f54f3e` → `15f5992` (`apps/cxs-mimir-chat/overlays/production/kustomization.yaml`)

Made with [Cursor](https://cursor.com)