### PR TITLE
chore: bump cxs-services production image tag to 00a8210

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "6401e42"
+    newTag: "00a8210"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
Bumps the `quicklookup/cxs-services` production image tag from `6401e42` to `00a8210`.

## Changes
- `apps/cxs-services/overlays/production/kustomization.yaml`: update `newTag` for `quicklookup/cxs-services`

ArgoCD will auto-sync the production deployment within ~3 minutes of merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)