### PR TITLE
chore: bump cxs-services production image tag to 1b49814

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "6636e34"
+    newTag: "1b49814"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
Bumps the cxs-services production image tag from `6636e34` to `1b49814`.

## Changes
- `apps/cxs-services/overlays/production/kustomization.yaml`: update `quicklookup/cxs-services` `newTag` → `1b49814`

ArgoCD will auto-sync the production deployment within ~3 minutes of merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)