### PR TITLE
chore: bump cxs-services production image tag to 7f82e96

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "1b49814"
+    newTag: "7f82e96"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Bump `quicklookup/cxs-services` production image tag from `1b49814` to `7f82e96`

ArgoCD will auto-sync this to production within ~3 minutes of merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)