### PR TITLE
chore: bump cxs-services and cxs-mimir-api production image tags

### DIFF
--- a/apps/cxs-mimir-api/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-mimir-api
-    newTag: "90e5218"
+    newTag: "ae5f11f"
 
 resources:
   - ../../base

--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "7f82e96"
+    newTag: "39c0c8e"
 
 resources:
   - ../../base


### PR DESCRIPTION
Bumps production image tags for two apps.

| App | Old tag | New tag |
|-----|---------|---------|
| `quicklookup/cxs-mimir-api` | `90e5218` | `ae5f11f` |
| `quicklookup/cxs-services` | `7f82e96` | `39c0c8e` |

Files changed:
- `apps/cxs-mimir-api/overlays/production/kustomization.yaml`
- `apps/cxs-services/overlays/production/kustomization.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)