### PR TITLE
chore: bump cxs-services production image tag to 65293ad

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "39c0c8e"
+    newTag: "65293ad"
 
 resources:
   - ../../base


### PR DESCRIPTION
Bumps the `quicklookup/cxs-services` production image tag from `39c0c8e` to `65293ad`.

ArgoCD will auto-sync the `apps-cxs-services` Application (namespace `solutions`) within ~3 minutes of merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)