### PR TITLE
chore: bump cxs-services production image tag to edb7f57

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "65293ad"
+    newTag: "edb7f57"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
- Bump `quicklookup/cxs-services` production image tag from `65293ad` to `edb7f57`

🤖 Generated with [Claude Code](https://claude.com/claude-code)