### PR TITLE
chore: bump cxs-services production image tag to 817e0a9

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "e85d391"
+    newTag: "817e0a9"
 
 resources:
   - ../../base


### PR DESCRIPTION
Bump cxs-services production image tag from `e85d391` to `817e0a9`.

ArgoCD will auto-sync the `apps-cxs-services` production deployment within ~3 minutes of merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)