### PR TITLE
chore: bump cxs-services production image tag to 60a0cad

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "817e0a9"
+    newTag: "60a0cad"
 
 resources:
   - ../../base


### PR DESCRIPTION
Bumps the cxs-services production image tag from `817e0a9` to `60a0cad`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)