### PR TITLE
chore: bump cxs-services production image tag to 8b6db89

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "60a0cad"
+    newTag: "8b6db89"
 
 resources:
   - ../../base


### PR DESCRIPTION
Bumps the `quicklookup/cxs-services` production image tag from `60a0cad` to `8b6db89`.

ArgoCD will auto-sync the `apps-cxs-services` production deployment within ~3 minutes of merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)