### PR TITLE
chore: update cxs-mimir-api image tag to 2989a27 for production

### DIFF
--- a/apps/cxs-mimir-api/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-mimir-api
-    newTag: "aac5d34"
+    newTag: "2989a27"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
Bumps the `quicklookup/cxs-mimir-api` production image tag from `aac5d34` to `2989a27`.

ArgoCD will auto-sync the `apps-cxs-mimir-api` Application (production overlay, `solutions` namespace) within ~3 minutes of merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)