### PR TITLE
chore: update cxs-mimir-api image tag to 07aca8e for production

### DIFF
--- a/apps/cxs-mimir-api/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-mimir-api
-    newTag: "2989a27"
+    newTag: "07aca8e"
 
 resources:
   - ../../base


### PR DESCRIPTION
Bumps the `quicklookup/cxs-mimir-api` production image tag to `07aca8e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)