### PR TITLE
chore: update cxs-services image tag to 37bacb3 for production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "8b6db89"
+    newTag: "37bacb3"
 
 resources:
   - ../../base


### PR DESCRIPTION
## Summary
Updates the `quicklookup/cxs-services` production image tag from `8b6db89` to `37bacb3`.

ArgoCD will auto-sync this change to production within ~3 minutes of merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)