### PR TITLE
chore: update cxs-services image tag to 3ace49b for production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "37bacb3"
+    newTag: "3ace49b"
 
 resources:
   - ../../base


### PR DESCRIPTION
Bumps the `quicklookup/cxs-services` production image tag to `3ace49b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)