### PR TITLE
chore: update cxs-services image tag to 3145b04 for production

### DIFF
--- a/apps/cxs-services/overlays/production/kustomization.yaml
+++ b/apps/cxs-services/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-services
-    newTag: "3ace49b"
+    newTag: "3145b04"
 
 resources:
   - ../../base


### PR DESCRIPTION
Bump `cxs-services` production image tag from `3ace49b` to `3145b04`.

ArgoCD will auto-sync the `apps-cxs-services` application (`solutions` namespace) within ~3 minutes of merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)