### PR TITLE
chore: update cxs-mimir-api image tag to 0a12060 for production

### DIFF
--- a/apps/cxs-mimir-api/overlays/production/kustomization.yaml
+++ b/apps/cxs-mimir-api/overlays/production/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: solutions
 
 images:
   - name: quicklookup/cxs-mimir-api
-    newTag: "07aca8e"
+    newTag: "0a12060"
 
 resources:
   - ../../base


### PR DESCRIPTION
Updates the `quicklookup/cxs-mimir-api` production image tag from `07aca8e` to `0a12060`.

ArgoCD will auto-sync the `apps-cxs-mimir-api` production application within ~3 minutes of merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)